### PR TITLE
feat: highlight search matches in note title and text

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,6 +83,25 @@ function autoLayout(notes) {
   return positions;
 }
 
+function highlightSearchMatches(content, query) {
+  if (!query || !query.trim()) return content;
+
+  const q = query.trim();
+  // String check aur safe conversion
+  const input = String(content ?? "");
+  const parts = input.split(new RegExp(`(${q})`, "gi"));
+
+  return parts.map((part, i) =>
+    part.toLowerCase() === q.toLowerCase() ? (
+      <mark key={i} className="search-highlight">
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  );
+}
+
 function linkifyText(text) {
   const input = String(text ?? "");
   const urlRegex = /((https?:\/\/|www\.)[^\s<>()]+[^\s<>().,!?;:"')\]])/gi;
@@ -440,7 +459,7 @@ export default function App() {
             >
               <div className={`note note-${c} ${images.length ? "note-has-image" : ""}`}>
                 <div className="note-header">
-                  <div className="note-title">{n.title || "(untitled)"}</div>
+                <div className="note-title">{highlightSearchMatches(n.title || "(untitled)", query)}</div>
                 </div>
 
                 <div className="note-body">
@@ -452,7 +471,7 @@ export default function App() {
                     </div>
                   ) : null}
 
-                  <div className="note-text">{linkifyText(text)}</div>
+                <div className="note-text">{highlightSearchMatches(linkifyText(text), query)}</div>
                 </div>
 
                 {(n.labels?.length || 0) > 0 ? (

--- a/src/app.css
+++ b/src/app.css
@@ -190,6 +190,12 @@ body{
   background: rgba(0,0,0,.12);
   font-size:12px;
 }
+.search-highlight {
+  background-color: #ffeb3b; /* Bright yellow */
+  color: #000;
+  padding: 0 2px;
+  border-radius: 2px;
+}
 
 @media (max-width: 900px){
   .topbar{


### PR DESCRIPTION
Description:
This PR adds a text-highlighting feature to search results. When a user types in the search bar, the matching keywords in the note titles and body text are highlighted with a yellow background.

Changes:

Added highlightSearchMatches utility function in App.jsx.

Wrapped note title and body text with the highlighting logic.

Added .search-highlight styles in app.css.

Testing:
Verified on both Web (localhost) and Electron desktop app using demo notes.